### PR TITLE
Standardize-parameter

### DIFF
--- a/python_interpreter/pipybench.py
+++ b/python_interpreter/pipybench.py
@@ -36,7 +36,7 @@ with open("output.json", "r") as output:
     benchmarks = json.load(output)
 
 result = {
-    "test_suite": "pybench",
+    "library": "pybench",
     "name": "PiPyBench",
     "@parameters": {
         "rounds": _ARGS_ROUNDS,

--- a/python_interpreter/pipyperformance.py
+++ b/python_interpreter/pipyperformance.py
@@ -50,7 +50,7 @@ with open("output.json", "r") as output:
     benchmarks = json.load(output)
 
 result = {
-    "test_suite": "performance",
+    "library": "performance",
     "name": "PiPyPerformance",
     "@parameters": {},
     "@result": benchmarks,

--- a/pytorch/conv1d.py
+++ b/pytorch/conv1d.py
@@ -199,7 +199,7 @@ def main():
     )
 
     result = {
-        "framework": "pytorch",
+        "library": "pytorch",
         "name": "PiConv2D",
         "@parameters": {
             "dtype": _ARGS_DTYPE,

--- a/pytorch/conv2d.py
+++ b/pytorch/conv2d.py
@@ -198,7 +198,7 @@ def main():
     )
 
     result = {
-        "framework": "pytorch",
+        "library": "pytorch",
         "name": "PiConv2D",
         "@parameters": {
             "dtype": _ARGS_DTYPE,

--- a/pytorch/matmul.py
+++ b/pytorch/matmul.py
@@ -141,7 +141,7 @@ def main():
     rate, elapsed = bench(_ARGS_MATRIX_SIZE)
 
     result = {
-        "framework": "pytorch",
+        "library": "pytorch",
         "name": "PiMatmul",
         "@parameters": {
             "dtype": _ARGS_DTYPE,

--- a/tensorflow/conv1d.py
+++ b/tensorflow/conv1d.py
@@ -209,7 +209,7 @@ def main():
     )
 
     result = {
-        "framework": "tensorflow",
+        "library": "tensorflow",
         "name": "PiConv1D",
         "@parameters": {
             "dtype": _ARGS_DTYPE,

--- a/tensorflow/conv2d.py
+++ b/tensorflow/conv2d.py
@@ -226,7 +226,7 @@ def main():
     )
 
     result = {
-        "framework": "tensorflow",
+        "library": "tensorflow",
         "name": "PiConv2D",
         "@parameters": {
             "dtype": _ARGS_DTYPE,

--- a/tensorflow/matmul.py
+++ b/tensorflow/matmul.py
@@ -105,7 +105,7 @@ def main():
     rate, elapsed = bench(_ARGS_MATRIX_SIZE)
 
     result = {
-        "framework": "tensorflow",
+        "library": "tensorflow",
         "name": "PiMatmul",
         "@parameters": {
             "dtype": _ARGS_DTYPE,


### PR DESCRIPTION
All parameters key need to be standardized in order to facilitate sync logic for inspections.
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>